### PR TITLE
Add support for resource pool upon create

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ resource "vsphere_vm" "machine_name" {
 }
 ```
 
+##Optional configuration
+```
+resource "vsphere_vm" "machine_name" {
+  ...
+  resource_pool = "Dev Cluster/Resources/Dev Pool"
+  ...
+}
+```
+
 ##How to build
 * go get
 * go install

--- a/test.tf
+++ b/test.tf
@@ -10,4 +10,5 @@ resource "vsphere_vm" "testing_vsphere_instance" {
   memory_mb = "8192"
   cpus = "4"
   customization_specification = "Ubuntu"
+  # resource_pool = "Dev Cluster/Resources/Dev Pool" # Optional
 }

--- a/vsphere/resource_vsphere_vm.go
+++ b/vsphere/resource_vsphere_vm.go
@@ -46,6 +46,10 @@ func resourceVsphereVM() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"resource_pool": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -69,10 +73,23 @@ func resourceVsphereVMCreate(d *schema.ResourceData, meta interface{}) error {
 
 	finder.SetDatacenter(datacenter)
 
-	resourcePool, err := finder.DefaultResourcePool(context.TODO())
+	var resourcePool *object.ResourcePool
 
-	if err != nil {
-		return err
+	resourcePoolName := d.Get("resource_pool").(string)
+
+	if resourcePoolName != "" {
+		resourcePool, err = finder.ResourcePool(context.TODO(), resourcePoolName)
+
+		if err != nil {
+			return err
+		}
+
+	} else {
+		resourcePool, err = finder.DefaultResourcePool(context.TODO())
+
+		if err != nil {
+			return err
+		}
 	}
 
 	rpRef := resourcePool.Reference()


### PR DESCRIPTION
This PR adds preliminary support for resource pools. I am not a Go programmer, so I'm open to improvements; please forgive any style transgressions or blatant omissions.

This was tested on a vSphere server with multiple resource pools - in fact, I had to add support for resource pools to avoid this error:

    * default resource pool resolves to multiple instances, please specify

I assume this does not occur on a vCenter environment with no more than one resource pool? I have no way at this time to test whether this patch works with such a environment. This works for me.

I'm aware there are a few different vSphere providers for Terraform. I have a specific need to work with resource pools, custom specifications, and the ability to deploy to multiple VLANs. Any pointers to help consolidate such code among the plugins would be greatly appreciated.